### PR TITLE
Fix: Invalid refs in sliding navigation

### DIFF
--- a/_includes/navigation-sliding.html
+++ b/_includes/navigation-sliding.html
@@ -2,7 +2,11 @@
   <h5>{{ site.title }} <span>{{ site.data.messages.locales[site.locale].toc }}</span></h5>
   <ul class="menu-item">
     {% for link in site.data.navigation %}<li>
-      <a href="{{ site.url }}{{ link.url }}">
+      {% if link.url contains 'http' %}
+        <a href="{{ link.url }}">
+        {% else %}
+        <a href="{{ site.url }}{{ link.url }}">
+      {% endif %}
         {% if link.image %}<img src="{{ site.url }}/images/{{ link.image }}" alt="teaser" class="teaser">{% endif %}
         <div class="title">{{ link.title }}</div>
         {% if link.excerpt %}<p class="excerpt">{{ link.excerpt }}</p>{% endif %}


### PR DESCRIPTION
Currently when in navigation data the `url`-property is not a relative path but actually a full url we still prefix that string with the base url of the blog (this is not the case for the static navigation). This results in invalid references. 

To reproduce simply click on **carrer** in the sliding navigation.

As a fix we add a condition (similar to that in the static navigation) to guard against wrong references being generated.
